### PR TITLE
refactor: reducing cyclomatic complexity of get_platforms

### DIFF
--- a/homeassistant/components/xiaomi_miio/__init__.py
+++ b/homeassistant/components/xiaomi_miio/__init__.py
@@ -136,6 +136,29 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
 
+def get_platforms_for_device(model):
+    """Return platforms for a given device model."""
+    model_platforms = {
+        **{model: SWITCH_PLATFORMS for model in MODELS_SWITCH},
+        **{model: HUMIDIFIER_PLATFORMS for model in MODELS_HUMIDIFIER},
+        **{model: FAN_PLATFORMS for model in MODELS_FAN},
+        **{model: LIGHT_PLATFORMS for model in MODELS_LIGHT},
+    }
+
+    if model in model_platforms:
+        return model_platforms[model]
+
+    for vacuum_model in MODELS_VACUUM:
+        if model.startswith(vacuum_model):
+            return VACUUM_PLATFORMS
+
+    for air_monitor_model in MODELS_AIR_MONITOR:
+        if model.startswith(air_monitor_model):
+            return AIR_MONITOR_PLATFORMS
+
+    return []
+
+
 @callback
 def get_platforms(config_entry):
     """Return the platforms belonging to a config_entry."""
@@ -145,20 +168,10 @@ def get_platforms(config_entry):
     if flow_type == CONF_GATEWAY:
         return GATEWAY_PLATFORMS
     if flow_type == CONF_DEVICE:
-        if model in MODELS_SWITCH:
-            return SWITCH_PLATFORMS
-        if model in MODELS_HUMIDIFIER:
-            return HUMIDIFIER_PLATFORMS
-        if model in MODELS_FAN:
-            return FAN_PLATFORMS
-        if model in MODELS_LIGHT:
-            return LIGHT_PLATFORMS
-        for vacuum_model in MODELS_VACUUM:
-            if model.startswith(vacuum_model):
-                return VACUUM_PLATFORMS
-        for air_monitor_model in MODELS_AIR_MONITOR:
-            if model.startswith(air_monitor_model):
-                return AIR_MONITOR_PLATFORMS
+        platforms = get_platforms_for_device(model)
+        if platforms:
+            return platforms
+
     _LOGGER.error(
         (
             "Unsupported device found! Please create an issue at "


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Reducing complexity of get_platforms function


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
