### PR TITLE
refactor: reduced cognitive complexity

### DIFF
--- a/homeassistant/components/xiaomi_miio/light.py
+++ b/homeassistant/components/xiaomi_miio/light.py
@@ -304,21 +304,23 @@ class XiaomiPhilipsAbstractLight(XiaomiMiioEntity, LightEntity):
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""
         if ATTR_BRIGHTNESS in kwargs:
-            brightness = kwargs[ATTR_BRIGHTNESS]
-            percent_brightness = ceil(100 * brightness / 255.0)
-
-            _LOGGER.debug(SET_BRIGHTNESS, brightness, percent_brightness)
-
-            result = await self._try_command(
-                "Setting brightness failed: %s",
-                self._device.set_brightness,
-                percent_brightness,
-            )
-
-            if result:
-                self._brightness = brightness
+            await self._adjust_brightness(kwargs[ATTR_BRIGHTNESS])
         else:
             await self._try_command(LIGHT_ON_FAILED, self._device.on)
+
+    async def _adjust_brightness(self, brightness: int) -> None:
+        """Adjust the brightness of the light."""
+        percent_brightness = ceil(100 * brightness / 255.0)
+        _LOGGER.debug(SET_BRIGHTNESS, brightness, percent_brightness)
+
+        result = await self._try_command(
+            "Setting brightness failed: %s",
+            self._device.set_brightness,
+            percent_brightness,
+        )
+
+        if result:
+            self._brightness = brightness
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the light off."""


### PR DESCRIPTION
## Reduced cognitive complexity
Reduced cognitive complexity of `async_turn_on ` from 21 to 15.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.